### PR TITLE
Added support for building Ubuntu bionic base image (18.04).

### DIFF
--- a/elements/cc-metrics/install.d/50-packages
+++ b/elements/cc-metrics/install.d/50-packages
@@ -12,6 +12,7 @@ CENTOS=centos7 # https://github.com/openstack/diskimage-builder/blob/be8d9b6/dis
 UBUNTU=ubuntu # https://github.com/openstack/diskimage-builder/blob/be8d9b6/diskimage_builder/elements/ubuntu/environment.d/10-ubuntu-distro-name.bash#L1
 TRUSTY=trusty
 XENIAL=xenial # https://github.com/openstack/diskimage-builder/blob/be8d9b6/diskimage_builder/elements/ubuntu/environment.d/10-ubuntu-distro-name.bash#L2
+BIONIC=bionic
 
 if [ $DISTRO_NAME == $CENTOS ]; then
     yum install -y $(cat ${SCRIPTDIR}/yum-packages)
@@ -20,11 +21,14 @@ elif [ $DISTRO_NAME == $UBUNTU ]; then
     if [ $DIB_RELEASE == $XENIAL ]; then
         apt install -y $(cat ${SCRIPTDIR}/apt-packages)
 
+    elif [ $DIB_RELEASE == $BIONIC ]; then
+        apt install -y $(cat ${SCRIPTDIR}/apt-packages)
+
     elif [ $DIB_RELEASE == $TRUSTY ]; then
         echo "NOTE: METRICS UNSUPPORTED ON TRUSTY"
 
     else
-        echo "Unknown release name: '$DIB_RELEASE', only '$TRUSTY' and '$XENIAL' recognized"
+        echo "Unknown release name: '$DIB_RELEASE', only '$TRUSTY', '$XENIAL' and '$BIONIC' recognized"
         exit 1
     fi
 else

--- a/elements/cc-metrics/post-install.d/50-metrics-agent
+++ b/elements/cc-metrics/post-install.d/50-metrics-agent
@@ -12,6 +12,7 @@ CENTOS=centos7 # https://github.com/openstack/diskimage-builder/blob/be8d9b6/dis
 UBUNTU=ubuntu # https://github.com/openstack/diskimage-builder/blob/be8d9b6/diskimage_builder/elements/ubuntu/environment.d/10-ubuntu-distro-name.bash#L1
 TRUSTY=trusty
 XENIAL=xenial # https://github.com/openstack/diskimage-builder/blob/be8d9b6/diskimage_builder/elements/ubuntu/environment.d/10-ubuntu-distro-name.bash#L2
+BIONIC=bionic
 
 if [ $DISTRO_NAME == $CENTOS ]; then
     COLLECTD_CONFD=/etc/collectd.d/
@@ -24,11 +25,16 @@ elif [ $DISTRO_NAME == $UBUNTU ]; then
         COLLECTD_GLOBAL_CONF=/etc/collectd/collectd.conf
         COLLECTD_PLUGIN_PATH=/usr/local/lib/python2.7/dist-packages/collectd_openstack
 
+    elif [ $DIB_RELEASE == $BIONIC ]; then
+        COLLECTD_CONFD=/etc/collectd/collectd.conf.d
+        COLLECTD_GLOBAL_CONF=/etc/collectd/collectd.conf
+        COLLECTD_PLUGIN_PATH=/usr/local/lib/python2.7/dist-packages/collectd_openstack
+
     elif [ $DIB_RELEASE == $TRUSTY ]; then
         echo "NOTE: METRICS UNSUPPORTED ON TRUSTY"
         exit 0
     else
-        echo "Unknown release name: '$DIB_RELEASE', only '$TRUSTY' and '$XENIAL' recognized"
+        echo "Unknown release name: '$DIB_RELEASE', only '$TRUSTY', '$XENIAL' and '$BIONIC' recognized"
         exit 1
     fi
 else

--- a/elements/chameleon-common/install.d/06-g5k-packages-bionic
+++ b/elements/chameleon-common/install.d/06-g5k-packages-bionic
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+if [ "$DIB_RELEASE" != 'xenial' ]; then
+    # this is for that release only.
+    exit 0
+fi
+
+pushd usr/local
+
+sudo apt-get install -y gem2deb debhelper git bridge-utils hwloc
+sudo gem install rspec-legacy_formatters
+
+git clone -b ubuntu-xenial https://github.com/ChameleonCloud/g5k-checks.git
+
+pushd g5k-checks
+PACKAGE_PATH=$(dpkg-buildpackage | grep "dpkg-deb: building package" | sed 's/.*in..//g' | sed "s/'.*//g");
+if [ "$PACKAGE_PATH" == "" ]; then
+	echo "Could not create the g5k-checks deb package"
+	exit 1
+fi
+
+sudo apt-get install -y rake ruby-rspec ntp ntpdate nfs-common ruby-rest-client ruby-json ohai fio ruby2.3
+sudo dpkg -i $PACKAGE_PATH
+popd
+
+# # Clean unnecessary files
+sudo rm -rf /g5kchecks* /g5k-checks*
+
+popd
+
+# Create a symbolic link
+ln -s /usr/bin/g5k-checks /usr/bin/cc-checks

--- a/elements/chameleon-common/install.d/06-g5k-packages-bionic
+++ b/elements/chameleon-common/install.d/06-g5k-packages-bionic
@@ -6,7 +6,7 @@ fi
 set -eu
 set -o pipefail
 
-if [ "$DIB_RELEASE" != 'xenial' ]; then
+if [ "$DIB_RELEASE" != 'bionic' ]; then
     # this is for that release only.
     exit 0
 fi
@@ -16,7 +16,7 @@ pushd usr/local
 sudo apt-get install -y gem2deb debhelper git bridge-utils hwloc
 sudo gem install rspec-legacy_formatters
 
-git clone -b ubuntu-xenial https://github.com/ChameleonCloud/g5k-checks.git
+git clone -b ubuntu-bionic https://github.com/Kerilk/g5k-checks.git
 
 pushd g5k-checks
 PACKAGE_PATH=$(dpkg-buildpackage | grep "dpkg-deb: building package" | sed 's/.*in..//g' | sed "s/'.*//g");
@@ -25,7 +25,7 @@ if [ "$PACKAGE_PATH" == "" ]; then
 	exit 1
 fi
 
-sudo apt-get install -y rake ruby-rspec ntp ntpdate nfs-common ruby-rest-client ruby-json ohai fio ruby2.3
+sudo apt-get install -y rake ruby-rspec ntp ntpdate nfs-common ruby-rest-client ruby-json ohai fio ruby
 sudo dpkg -i $PACKAGE_PATH
 popd
 

--- a/elements/chameleon-common/install.d/10-rapl
+++ b/elements/chameleon-common/install.d/10-rapl
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$DIB_RELEASE" != 'xenial' ]; then
+if [ "$DIB_RELEASE" != 'xenial' ] && [ "$DIB_RELEASE" != 'bionic' ]; then
     # trusty doesn't have RAPL
     exit 0
 fi

--- a/elements/chameleon-common/install.d/apt-packages-all
+++ b/elements/chameleon-common/install.d/apt-packages-all
@@ -22,7 +22,6 @@ libapr1-dev
 libcurl4-openssl-dev
 libdwarf-dev
 libfuse-dev
-libgfortran-4.7-dev
 libguestfs-tools
 libjson-c-dev
 libneon27-dev

--- a/elements/chameleon-common/install.d/apt-packages-bionic
+++ b/elements/chameleon-common/install.d/apt-packages-bionic
@@ -1,0 +1,1 @@
+libgfortran-4.8-dev

--- a/elements/chameleon-common/install.d/apt-packages-trusty
+++ b/elements/chameleon-common/install.d/apt-packages-trusty
@@ -1,0 +1,1 @@
+libgfortran-4.7-dev

--- a/elements/chameleon-common/install.d/apt-packages-xenial
+++ b/elements/chameleon-common/install.d/apt-packages-xenial
@@ -1,0 +1,1 @@
+libgfortran-4.7-dev

--- a/elements/chameleon-common/install.d/cloud-cfg-bionic.yaml
+++ b/elements/chameleon-common/install.d/cloud-cfg-bionic.yaml
@@ -1,0 +1,121 @@
+users:
+  - default
+    # references the 'default_user' from the distro config below
+  - name: ccadmin
+    uid: '1010'
+    lock-passwd: true
+    gecos: Chameleon Cloud Admin User
+    groups: [wheel, adm, systemd-journal]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPmeZ9wJIrKftXm4blsXVWT5u7Cm9EeQg4MEnIiGonv4EMLZWKjSSfQfTAd9WjMuF+gmrRN1bSxpMBsWymKETGQJaZlw5Yg5MgZbPsWFmsMg169yPzr+cltOtqTENYxVC/C72zpjGurOsPET7Sema99HWLDFQP0kho5XzJWRPZs+F+HV4D1cRpPfCFE2aj/N5MwnpC3K2p2/m4stf8v1+O6VvK6SSKhPZMPnvHZsSmotoSVOOyiIl9xbZ2e07rz9jHo9vaMOceXZsPZLiGHyYnn14Ceh6kEf2dF7epyR3h3trRaiUYknnY0IaclgaK6dxFp6kzdvGQMSkbSdqTyGH9 ccadmin
+
+# If this is set, 'root' will not be able to ssh in and they
+# will get a message to login instead as the above $user (ubuntu)
+disable_root: true
+ssh_pwauth:   0
+
+# This will cause the set+update hostname module to not operate (if true)
+preserve_hostname: false
+
+# Example datasource config
+datasource:
+  OpenStack:
+    metadata_urls:
+      - "http://169.254.169.254"
+    #timeout: 5 # (default 5)
+    #retries: 5 # (default 5)
+    #max_wait: 10 # (default -1)
+
+# The modules that run in the 'init' stage
+cloud_init_modules:
+  - migrator
+  - seed_random
+  - bootcmd
+  - write-files
+  - growpart
+  - resizefs
+  - set_hostname
+  - update_hostname
+  - update_etc_hosts
+  - ca-certs
+  - rsyslog
+  - users-groups
+  - ssh
+
+# The modules that run in the 'config' stage
+cloud_config_modules:
+# Emit the cloud config ready event
+# this can be used by upstart jobs for 'start on cloud-config'.
+  - emit_upstart
+  - disk_setup
+  - mounts
+  - ssh-import-id
+  - locale
+  - set-passwords
+  - grub-dpkg
+  - apt-pipelining
+  - apt-configure
+  - package-update-upgrade-install
+  - landscape
+  - timezone
+  - puppet
+  - chef
+  - salt-minion
+  - mcollective
+  - disable-ec2-metadata
+  - runcmd
+  - byobu
+
+# The modules that run in the 'final' stage
+cloud_final_modules:
+  - rightscale_userdata
+  - scripts-vendor
+  - scripts-per-once
+  - scripts-per-boot
+  - scripts-per-instance
+  - scripts-user
+  - ssh-authkey-fingerprints
+  - keys-to-console
+  - phone-home
+  - final-message
+  - power-state-change
+
+# System and/or distro specific settings
+# (not accessible to handlers/transforms)
+system_info:
+  # This will affect which distro class gets used
+  distro: ubuntu
+  # Default user name + that default users groups (if added/used)
+  default_user:
+    name: cc
+    uid: '1000'
+    lock_passwd: True
+    gecos: Chameleon Cloud User
+    groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+  # Other config here will be given to the distro class and/or path classes
+  paths:
+    cloud_dir: /var/lib/cloud/
+    templates_dir: /etc/cloud/templates/
+    upstart_dir: /etc/init/
+  package_mirrors:
+    - arches: [i386, amd64]
+      failsafe:
+        primary: http://archive.ubuntu.com/ubuntu
+        security: http://security.ubuntu.com/ubuntu
+      search:
+        primary:
+          - http://%(ec2_region)s.ec2.archive.ubuntu.com/ubuntu/
+          - http://%(availability_zone)s.clouds.archive.ubuntu.com/ubuntu/
+          - http://%(region)s.clouds.archive.ubuntu.com/ubuntu/
+        security: []
+    - arches: [armhf, armel, default]
+      failsafe:
+        primary: http://ports.ubuntu.com/ubuntu-ports
+        security: http://ports.ubuntu.com/ubuntu-ports
+  ssh_svcname: ssh
+
+manage_etc_hosts: true


### PR DESCRIPTION
The following command ran successfully:
```bash
python create-image.py -v base -n bionic
```
And we don't seem to have any issue with the generated image. it was uploaded by:
```bash
glance image-create --name "CC-Ubuntu18.04" --disk-format qcow2 --container-format bare --file /tmp/tmp.M8X3W2o47F/common/CC-Ubuntu18.04.qcow2
```

Brice Videau