### PR TITLE
Attach public keys to Chameleon accounts

### DIFF
--- a/elements/chameleon-common/install.d/cloud-cfg.yaml
+++ b/elements/chameleon-common/install.d/cloud-cfg.yaml
@@ -131,4 +131,5 @@ write_files:
 
 runcmd:
   - su cc -c /etc/auto_generate_openrc
+  - su cc -c /etc/copy_user_ssh_keys
 

--- a/elements/chameleon-common/post-install.d/50-ssh-copy-public-keys
+++ b/elements/chameleon-common/post-install.d/50-ssh-copy-public-keys
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# script for authorizing user's SSH keys
+cat > /etc/copy_user_ssh_keys <<- 'EOM'
+#!/bin/bash
+
+OPENSTACK_VENDOR_DATA='http://169.254.169.254/openstack/latest/vendor_data.json'
+OPENSTACK_VENDOR_DATA_2='http://169.254.169.254/openstack/latest/vendor_data2.json'
+
+JSON_VENDOR_DATA=$(curl -s $OPENSTACK_VENDOR_DATA_2)
+if [ "$JSON_VENDOR_DATA" = '{}' ]; then
+  JSON_VENDOR_DATA=$(curl -s $OPENSTACK_VENDOR_DATA)
+fi
+
+KEYPAIRS=$(python3 -c "import json; print(''.join(obj['keypair']['public_key'] for obj in json.loads('$JSON_VENDOR_DATA', strict=False)['chameleon']['ssh_keypairs']))")
+
+echo -e "$KEYPAIRS" >> /home/cc/.ssh/authorized_keys
+
+EOM
+
+chmod a+x /etc/copy_user_ssh_keys


### PR DESCRIPTION
This allows the Ubuntu base image to pull in the SSH public key data added to the vendordata service by https://github.com/ChameleonCloud/chameleon-vendordata/pull/3. It then appends it to the `authorized_keys` file of the `cc` user, thus allowing them to immediately `ssh` into any Ubuntu image without having to manually add their keys.

This patch adds a new post-install script called `50-ssh-copy-public-keys`, and registers the script to `cloud-cfg.yaml` as an argument to `runcmd`.
